### PR TITLE
Fixes a bug in which registered 'rendered' callbacks are ignored and lost

### DIFF
--- a/modules/ngMeteor-template.js
+++ b/modules/ngMeteor-template.js
@@ -31,19 +31,21 @@ ngMeteorTemplate.directive('ngTemplate', ['$templateCache', '$compile',
 
 // Re-compiles template when rendering with Iron-Router
 angular.element(document).ready(function() {
-	if(Package['iron-router']){
-		var oldRun = Router.run;
-		Router.run = function() {
-			var runResult = oldRun.apply(this, arguments);
-			key = this._currentController.template
-			Template[key].rendered = function(){
-				angular.element(document).injector().invoke(['$compile', '$document', '$rootScope', function($compile, $document, $rootScope){
-					$compile($document)($rootScope);
-					$rootScope.$digest();
-				}]);
-				Template[key].rendered = null;
-			}
-			return runResult;
-		};
-	}
+    if(Package['iron-router']){
+        var oldRun = Router.run;
+        Router.run = function() {
+            var runResult = oldRun.apply(this, arguments);
+            key = this._currentController.template
+            var oldRendered = Template[key].rendered;
+            Template[key].rendered = function(){
+                angular.element(document).injector().invoke(['$compile', '$document', '$rootScope', function($compile, $document, $rootScope){
+                    $compile($document)($rootScope);
+                    $rootScope.$digest();
+                    oldRendered.apply(this, arguments);
+                }]);
+                Template[key].rendered = oldRendered;
+            }
+            return runResult;
+        };
+    }
 });


### PR DESCRIPTION
Fixes bug in which 'rendered' callbacks registered on templates rendered through iron-router were overridden and lost when angular compile/digest cycle was incorporated.

This fix is implemented by caching any registered 'rendered' callback and then applying that callback after the angular compile/digest cycle is completed. After that, it then re-registers that cached function as the 'rendered' callback on the template.
